### PR TITLE
Two profiles syntax fix and switch goal to verify

### DIFF
--- a/src/org/clg/pipeline/build.groovy
+++ b/src/org/clg/pipeline/build.groovy
@@ -33,7 +33,7 @@ def build(def params) {
         // We need to use profile, and run ITs via verify phase
         if (readFile('pom.xml').contains(contrast)) {
           phase = "verify"
-          profiles += contrast
+          profiles.add("contrast")
         }
          
         sh """mvn -B -Dmaven.wagon.http.ssl.insecure=true 

--- a/src/org/clg/pipeline/build.groovy
+++ b/src/org/clg/pipeline/build.groovy
@@ -38,7 +38,7 @@ def build(def params) {
          
         sh """mvn -B -Dmaven.wagon.http.ssl.insecure=true 
                   -s /maven-conf/settings.xml 
-                  -P ${profiles.join[',']}"
+                  -P ${profiles.join(',')}"
                   -DappName=app ${phase}"""
       }
 

--- a/src/org/clg/pipeline/build.groovy
+++ b/src/org/clg/pipeline/build.groovy
@@ -25,7 +25,7 @@ def build(def params) {
       }
 
       stage('Build From Source') {
-        sh "mvn -B -Dmaven.wagon.http.ssl.insecure=true -s /maven-conf/settings.xml -P ocp -P run-with-contrast -DappName=app package"
+        sh "mvn -B -Dmaven.wagon.http.ssl.insecure=true -s /maven-conf/settings.xml -P ocp,run-with-contrast -DappName=app verify"
       }
 
       stage("Process OpenShift Config") {


### PR DESCRIPTION
We used the wrong syntax for applying two profiles... and also the Verify (Integration test) step of the maven lifecycle comes AFTER package, so with just a package command the ITs were not being run.